### PR TITLE
Fix compilation and Better organize all sub-projects into folders in Visual Studio

### DIFF
--- a/02_Qualities/CMakeLists.txt
+++ b/02_Qualities/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "02_Qualities")
+
 # Specify the subdirectories to build
 add_subdirectory(hide_class)
 add_subdirectory(coord2d_template)

--- a/02_Qualities/callback_instance/CMakeLists.txt
+++ b/02_Qualities/callback_instance/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # Build the executable
 add_executable(callback_instance main.cpp modulea.cpp moduleb.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(callback_instance PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/02_Qualities/callback_static/CMakeLists.txt
+++ b/02_Qualities/callback_static/CMakeLists.txt
@@ -10,5 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(callback_static main.cpp modulea.cpp moduleb.cpp)
 
-
-
+# Set parent folder for organization in Visual Studio project
+set_target_properties(callback_static PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/02_Qualities/coord2d_template/CMakeLists.txt
+++ b/02_Qualities/coord2d_template/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(coord2d_template main.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(coord2d_template PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/02_Qualities/hide_class/CMakeLists.txt
+++ b/02_Qualities/hide_class/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(hide_class main.cpp fireworks.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(hide_class PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/02_Qualities/shared_pointer/CMakeLists.txt
+++ b/02_Qualities/shared_pointer/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(shared_pointer main.cpp myobject.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(shared_pointer PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/CMakeLists.txt
+++ b/03_Patterns/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "03_Patterns")
+
 # Specify the subdirectories to build
 add_subdirectory(pimpl_bad)
 add_subdirectory(pimpl_good)

--- a/03_Patterns/adapter/CMakeLists.txt
+++ b/03_Patterns/adapter/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(adapter main.cpp adapter.cpp original.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(adapter PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/facade/CMakeLists.txt
+++ b/03_Patterns/facade/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(facade main.cpp facade.cpp original.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(facade PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/factory_extensible/CMakeLists.txt
+++ b/03_Patterns/factory_extensible/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(factory_extensible main.cpp rendererfactory.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(factory_extensible PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/factory_simple/CMakeLists.txt
+++ b/03_Patterns/factory_simple/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(factory_simple main.cpp rendererfactory.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(factory_simple PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/observer/CMakeLists.txt
+++ b/03_Patterns/observer/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(observer main.cpp subject.cpp observer.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(observer PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/opaque_pointer/CMakeLists.txt
+++ b/03_Patterns/opaque_pointer/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(opaque_pointer main.c autotimer.c)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(opaque_pointer PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/pimpl_bad/CMakeLists.txt
+++ b/03_Patterns/pimpl_bad/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(pimpl_bad main.cpp autotimer.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(pimpl_bad PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/pimpl_boost/CMakeLists.txt
+++ b/03_Patterns/pimpl_boost/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(pimpl_boost main.cpp autotimer.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(pimpl_boost PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/pimpl_good/CMakeLists.txt
+++ b/03_Patterns/pimpl_good/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(pimp_good main.cpp autotimer.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(pimp_good PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/proxy_interface/CMakeLists.txt
+++ b/03_Patterns/proxy_interface/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(proxy_interface main.cpp proxy.cpp original.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(proxy_interface PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/proxy_simple/CMakeLists.txt
+++ b/03_Patterns/proxy_simple/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(proxy_simple main.cpp proxy.cpp original.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(proxy_simple PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/03_Patterns/singleton/CMakeLists.txt
+++ b/03_Patterns/singleton/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(singleton main.cpp singleton.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(singleton PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/04_Design/CMakeLists.txt
+++ b/04_Design/CMakeLists.txt
@@ -7,5 +7,8 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "04_Design")
+
 # Specify the subdirectories to build
 add_subdirectory(named_parameters)

--- a/04_Design/named_parameters/CMakeLists.txt
+++ b/04_Design/named_parameters/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(named_parameters main.cpp timer.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(named_parameters PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/05_Styles/CMakeLists.txt
+++ b/05_Styles/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "05_Styles")
+
 # Specify the subdirectories to build
 add_subdirectory(stack_c)
 add_subdirectory(stack_cpp)

--- a/05_Styles/stack_c/CMakeLists.txt
+++ b/05_Styles/stack_c/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(stack_c main.c stack.c)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(stack_c PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/05_Styles/stack_cpp/CMakeLists.txt
+++ b/05_Styles/stack_cpp/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(stack_cpp main.cpp stack.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(stack_cpp PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/05_Styles/stack_datadriven/CMakeLists.txt
+++ b/05_Styles/stack_datadriven/CMakeLists.txt
@@ -13,3 +13,6 @@ add_executable(stack_datadriven main.cpp stack.cpp arglist.cpp)
 # Build the test program for the arglist module
 add_executable(arglist_test arglist_test.cpp arglist.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(stack_datadriven PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
+set_target_properties(arglist_test PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/05_Styles/stack_preprocessor/CMakeLists.txt
+++ b/05_Styles/stack_preprocessor/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(stack_preprocessor main.cpp stack.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(stack_preprocessor PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/05_Styles/stack_template/CMakeLists.txt
+++ b/05_Styles/stack_template/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(stack_template main.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(stack_template PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/06_Cpp_Style/CMakeLists.txt
+++ b/06_Cpp_Style/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "06_Cpp_Style")
+
 # Specify the subdirectories to build
 add_subdirectory(constructors)
 add_subdirectory(operators)

--- a/06_Cpp_Style/bad_friends/CMakeLists.txt
+++ b/06_Cpp_Style/bad_friends/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # Build the executable
 add_executable(bad_friends main.cpp node.cpp graph.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(bad_friends PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/06_Cpp_Style/constructors/CMakeLists.txt
+++ b/06_Cpp_Style/constructors/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(constructors main.cpp array.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(constructors PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/06_Cpp_Style/extern_leakage/CMakeLists.txt
+++ b/06_Cpp_Style/extern_leakage/CMakeLists.txt
@@ -10,5 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(extern_leakage main.cpp myobject.cpp)
 
-
-
+# Set parent folder for organization in Visual Studio project
+set_target_properties(extern_leakage PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/06_Cpp_Style/operators/CMakeLists.txt
+++ b/06_Cpp_Style/operators/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(operators main.cpp currency.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(operators PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/06_Cpp_Style/template_explicit/CMakeLists.txt
+++ b/06_Cpp_Style/template_explicit/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(template_explicit main.cpp stack.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(template_explicit PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/06_Cpp_Style/template_polymorphism/CMakeLists.txt
+++ b/06_Cpp_Style/template_polymorphism/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(template_polymorphism main.cpp file.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(template_polymorphism PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/06_Cpp_Style/template_specialization/CMakeLists.txt
+++ b/06_Cpp_Style/template_specialization/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(template_specialization main.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(template_specialization PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/07_Performance/CMakeLists.txt
+++ b/07_Performance/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "07_Performance")
+
 # Specify the subdirectories to build
 add_subdirectory(auto_timer)
 add_subdirectory(const_reference)

--- a/07_Performance/auto_timer/CMakeLists.txt
+++ b/07_Performance/auto_timer/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the library
 add_library(autotimer STATIC autotimer.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(autotimer PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/07_Performance/const_reference/CMakeLists.txt
+++ b/07_Performance/const_reference/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(const_reference main.cpp myobject.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(const_reference PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/07_Performance/copy_on_write/CMakeLists.txt
+++ b/07_Performance/copy_on_write/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # Build the executable
 add_executable(copy_on_write main.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(copy_on_write PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/07_Performance/getter_speed/CMakeLists.txt
+++ b/07_Performance/getter_speed/CMakeLists.txt
@@ -17,3 +17,5 @@ add_executable(getter_speed main.cpp vector.cpp)
 # Link against the AutoTimer library
 target_link_libraries(getter_speed autotimer)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(getter_speed PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/07_Performance/iterators/CMakeLists.txt
+++ b/07_Performance/iterators/CMakeLists.txt
@@ -16,3 +16,6 @@ add_executable(iterators main.cpp value.cpp)
 
 # Link against the AutoTimer library
 target_link_libraries(iterators autotimer)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(iterators PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/07_Performance/struct_size/CMakeLists.txt
+++ b/07_Performance/struct_size/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(struct_size main.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(struct_size PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/07_Performance/virtual_speed/CMakeLists.txt
+++ b/07_Performance/virtual_speed/CMakeLists.txt
@@ -16,3 +16,6 @@ add_executable(virtual_speed main.cpp myclass.cpp)
 
 # Link against the AutoTimer library
 target_link_libraries(virtual_speed autotimer)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(virtual_speed PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/08_Versioning/CMakeLists.txt
+++ b/08_Versioning/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "08_Versioning")
+
 # Specify the subdirectories to build
 add_subdirectory(version_api)
 add_subdirectory(deprecate_compiletime)

--- a/08_Versioning/deprecate_compiletime/CMakeLists.txt
+++ b/08_Versioning/deprecate_compiletime/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(deprecate_compiletime main.cpp myclass.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(deprecate_compiletime PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/08_Versioning/deprecate_runtime/CMakeLists.txt
+++ b/08_Versioning/deprecate_runtime/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(deprecate_runtime main.cpp myclass.cpp deprecated.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(deprecate_runtime PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/08_Versioning/version_api/CMakeLists.txt
+++ b/08_Versioning/version_api/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(version_api main.cpp version.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(version_api PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/09_Documentation/CMakeLists.txt
+++ b/09_Documentation/CMakeLists.txt
@@ -7,5 +7,8 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "09_Documentation")
+
 # Don't build by default - requires user to install doxygen
 #add_subdirectory(doxygen)

--- a/10_Testing/CMakeLists.txt
+++ b/10_Testing/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "10_Testing")
+
 # Specify the subdirectories to build
 add_subdirectory(self_test)
 add_subdirectory(unit_test)

--- a/10_Testing/self_test/CMakeLists.txt
+++ b/10_Testing/self_test/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(self_test main.cpp bbox.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(self_test PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/10_Testing/unit_test/CMakeLists.txt
+++ b/10_Testing/unit_test/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(unit_test main.cpp stringutil.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(unit_test PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/10_Testing/wargame/CMakeLists.txt
+++ b/10_Testing/wargame/CMakeLists.txt
@@ -17,3 +17,7 @@ add_executable(test_stub test_stub.cpp wargame.cpp)
 
 add_executable(test_mock test_mock.cpp wargame.cpp)
 target_link_libraries(test_mock gmock gtest)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(test_stub PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
+set_target_properties(test_mock PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/11_Scripting/CMakeLists.txt
+++ b/11_Scripting/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "11_Scripting")
+
 # See python/CMakeLists.txt for details before enabling this
 #add_subdirectory(python)
 

--- a/11_Scripting/python/CMakeLists.txt
+++ b/11_Scripting/python/CMakeLists.txt
@@ -38,3 +38,6 @@ if ("${CMAKE_SYSTEM_NAME}" MATCHES "Darwin")
   #set_target_properties(phonebook PROPERTIES OUTPUT_NAME phonebook)
   set_target_properties(phonebook PROPERTIES SUFFIX .so)
 endif ()
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(phonebook PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/11_Scripting/ruby/CMakeLists.txt
+++ b/11_Scripting/ruby/CMakeLists.txt
@@ -65,3 +65,8 @@ add_custom_target(run
   COMMAND "${RUBY_BIN}" "${INSTALL_DIR}/main.rb"
   WORKING_DIRECTORY ${INSTALL_DIR}
 )
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(install PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
+set_target_properties(run PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
+

--- a/12_Extensibility/CMakeLists.txt
+++ b/12_Extensibility/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "12_Extensibility")
+
 # Specify the subdirectories to build
 add_subdirectory(plugin_api)
 add_subdirectory(visitor)

--- a/12_Extensibility/curious_templates/CMakeLists.txt
+++ b/12_Extensibility/curious_templates/CMakeLists.txt
@@ -10,3 +10,5 @@ cmake_minimum_required(VERSION 2.4)
 # Build the executable
 add_executable(curious_templates main.cpp)
 
+# Set parent folder for organization in Visual Studio project
+set_target_properties(curious_templates PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/12_Extensibility/plugin_api/CMakeLists.txt
+++ b/12_Extensibility/plugin_api/CMakeLists.txt
@@ -21,13 +21,16 @@ set_target_properties(coreapi PROPERTIES DEFINE_SYMBOL BUILDING_CORE)
 
 add_library(plugin1 SHARED plugin1.cpp)
 target_link_libraries(plugin1 coreapi)
+set_target_properties(plugin1 PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
 
 add_library(plugin2 SHARED plugin2.cpp)
 target_link_libraries(plugin2 coreapi)
+set_target_properties(plugin2 PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
 
 # create the libraries
 add_executable(plugin_api main.cpp)
 target_link_libraries(plugin_api coreapi)
+set_target_properties(plugin_api PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
 
 if (WIN32)
    find_library(DL_LIB Kernel32)

--- a/12_Extensibility/plugin_api/CMakeLists.txt
+++ b/12_Extensibility/plugin_api/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(plugin_api main.cpp)
 target_link_libraries(plugin_api coreapi)
 
 if (WIN32)
-   find_library(DL_LIB Kernel32.dll)
+   find_library(DL_LIB Kernel32)
 else ()
    find_library(DL_LIB dl)
 endif ()

--- a/12_Extensibility/visitor/CMakeLists.txt
+++ b/12_Extensibility/visitor/CMakeLists.txt
@@ -9,3 +9,6 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the libraries
 add_executable(visitor main.cpp scenegraph.cpp)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(visitor PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/AA_Libraries/CMakeLists.txt
+++ b/AA_Libraries/CMakeLists.txt
@@ -7,6 +7,9 @@
 # Declare the minimum version of cmake that we need
 cmake_minimum_required(VERSION 2.4)
 
+# Shared variables for all child CMakeLists.txt
+set(VS_PARENT_FOLDER "AA_Libraries")
+
 # These directories only build under GCC
 if (CMAKE_COMPILER_IS_GNUCC)
   add_subdirectory(gcc_entry_point)

--- a/AA_Libraries/gcc_entry_point/CMakeLists.txt
+++ b/AA_Libraries/gcc_entry_point/CMakeLists.txt
@@ -12,3 +12,6 @@ add_library(library SHARED library.cpp)
 
 add_executable(gcc_entry_point main.cpp)
 target_link_libraries(gcc_entry_point library)
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(gcc_entry_point PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/AA_Libraries/gcc_plugin/CMakeLists.txt
+++ b/AA_Libraries/gcc_plugin/CMakeLists.txt
@@ -9,7 +9,11 @@ cmake_minimum_required(VERSION 2.4)
 
 # create the library
 add_library(plugin SHARED plugin.cpp)
+set_target_properties(plugin PROPERTIES FOLDER "${VS_PARENT_FOLDER}")
 
 add_executable(gcc_plugin main.cpp)
 find_library(DL_LIB dl)
 target_link_libraries(gcc_plugin ${DL_LIB})
+
+# Set parent folder for organization in Visual Studio project
+set_target_properties(gcc_plugin PROPERTIES FOLDER "${VS_PARENT_FOLDER}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,9 @@ cmake_minimum_required(VERSION 2.4)
 # Setup the name for this CMake project
 project(APIBook)
 
+# Set to enable using folders in Visual Studio project
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 # add our external include path (for Boost headers)
 include_directories("${CMAKE_SOURCE_DIR}/external")
 

--- a/external/boost/detail/interlocked.hpp
+++ b/external/boost/detail/interlocked.hpp
@@ -1,0 +1,142 @@
+#ifndef BOOST_DETAIL_INTERLOCKED_HPP_INCLUDED
+#define BOOST_DETAIL_INTERLOCKED_HPP_INCLUDED
+
+// MS compatible compilers support #pragma once
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+# pragma once
+#endif
+
+//
+//  boost/detail/interlocked.hpp
+//
+//  Copyright 2005 Peter Dimov
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include <boost/config.hpp>
+
+#if defined( BOOST_USE_WINDOWS_H )
+
+# include <windows.h>
+
+# define BOOST_INTERLOCKED_INCREMENT InterlockedIncrement
+# define BOOST_INTERLOCKED_DECREMENT InterlockedDecrement
+# define BOOST_INTERLOCKED_COMPARE_EXCHANGE InterlockedCompareExchange
+# define BOOST_INTERLOCKED_EXCHANGE InterlockedExchange
+# define BOOST_INTERLOCKED_EXCHANGE_ADD InterlockedExchangeAdd
+# define BOOST_INTERLOCKED_COMPARE_EXCHANGE_POINTER InterlockedCompareExchangePointer
+# define BOOST_INTERLOCKED_EXCHANGE_POINTER InterlockedExchangePointer
+
+#elif defined(_WIN32_WCE)
+
+// under Windows CE we still have old-style Interlocked* functions
+
+extern "C" long __cdecl InterlockedIncrement( long* );
+extern "C" long __cdecl InterlockedDecrement( long* );
+extern "C" long __cdecl InterlockedCompareExchange( long*, long, long );
+extern "C" long __cdecl InterlockedExchange( long*, long );
+extern "C" long __cdecl InterlockedExchangeAdd( long*, long );
+
+# define BOOST_INTERLOCKED_INCREMENT InterlockedIncrement
+# define BOOST_INTERLOCKED_DECREMENT InterlockedDecrement
+# define BOOST_INTERLOCKED_COMPARE_EXCHANGE InterlockedCompareExchange
+# define BOOST_INTERLOCKED_EXCHANGE InterlockedExchange
+# define BOOST_INTERLOCKED_EXCHANGE_ADD InterlockedExchangeAdd
+
+# define BOOST_INTERLOCKED_COMPARE_EXCHANGE_POINTER(dest,exchange,compare) \
+    ((void*)BOOST_INTERLOCKED_COMPARE_EXCHANGE((long*)(dest),(long)(exchange),(long)(compare)))
+# define BOOST_INTERLOCKED_EXCHANGE_POINTER(dest,exchange) \
+    ((void*)BOOST_INTERLOCKED_EXCHANGE((long*)(dest),(long)(exchange)))
+
+#elif defined( BOOST_MSVC ) || defined( BOOST_INTEL_WIN )
+
+#if defined( __CLRCALL_PURE_OR_CDECL )
+
+extern "C" long __CLRCALL_PURE_OR_CDECL _InterlockedIncrement( long volatile * );
+extern "C" long __CLRCALL_PURE_OR_CDECL _InterlockedDecrement( long volatile * );
+extern "C" long __CLRCALL_PURE_OR_CDECL _InterlockedCompareExchange( long volatile *, long, long );
+extern "C" long __CLRCALL_PURE_OR_CDECL _InterlockedExchange( long volatile *, long );
+extern "C" long __CLRCALL_PURE_OR_CDECL _InterlockedExchangeAdd( long volatile *, long );
+
+#else
+
+extern "C" long __cdecl _InterlockedIncrement( long volatile * );
+extern "C" long __cdecl _InterlockedDecrement( long volatile * );
+extern "C" long __cdecl _InterlockedCompareExchange( long volatile *, long, long );
+extern "C" long __cdecl _InterlockedExchange( long volatile *, long );
+extern "C" long __cdecl _InterlockedExchangeAdd( long volatile *, long );
+
+#endif
+
+# pragma intrinsic( _InterlockedIncrement )
+# pragma intrinsic( _InterlockedDecrement )
+# pragma intrinsic( _InterlockedCompareExchange )
+# pragma intrinsic( _InterlockedExchange )
+# pragma intrinsic( _InterlockedExchangeAdd )
+
+# if defined(_M_IA64) || defined(_M_AMD64)
+
+extern "C" void* __cdecl _InterlockedCompareExchangePointer( void* volatile *, void*, void* );
+extern "C" void* __cdecl _InterlockedExchangePointer( void* volatile *, void* );
+
+#  pragma intrinsic( _InterlockedCompareExchangePointer )
+#  pragma intrinsic( _InterlockedExchangePointer )
+
+#  define BOOST_INTERLOCKED_COMPARE_EXCHANGE_POINTER _InterlockedCompareExchangePointer
+#  define BOOST_INTERLOCKED_EXCHANGE_POINTER _InterlockedExchangePointer
+
+# else
+
+#  define BOOST_INTERLOCKED_COMPARE_EXCHANGE_POINTER(dest,exchange,compare) \
+    ((void*)BOOST_INTERLOCKED_COMPARE_EXCHANGE((long volatile*)(dest),(long)(exchange),(long)(compare)))
+#  define BOOST_INTERLOCKED_EXCHANGE_POINTER(dest,exchange) \
+    ((void*)BOOST_INTERLOCKED_EXCHANGE((long volatile*)(dest),(long)(exchange)))
+
+# endif
+
+# define BOOST_INTERLOCKED_INCREMENT _InterlockedIncrement
+# define BOOST_INTERLOCKED_DECREMENT _InterlockedDecrement
+# define BOOST_INTERLOCKED_COMPARE_EXCHANGE _InterlockedCompareExchange
+# define BOOST_INTERLOCKED_EXCHANGE _InterlockedExchange
+# define BOOST_INTERLOCKED_EXCHANGE_ADD _InterlockedExchangeAdd
+
+#elif defined( WIN32 ) || defined( _WIN32 ) || defined( __WIN32__ ) || defined( __CYGWIN__ )
+
+namespace boost
+{
+
+namespace detail
+{
+
+extern "C" __declspec(dllimport) long __stdcall InterlockedIncrement( long volatile * );
+extern "C" __declspec(dllimport) long __stdcall InterlockedDecrement( long volatile * );
+extern "C" __declspec(dllimport) long __stdcall InterlockedCompareExchange( long volatile *, long, long );
+extern "C" __declspec(dllimport) long __stdcall InterlockedExchange( long volatile *, long );
+extern "C" __declspec(dllimport) long __stdcall InterlockedExchangeAdd( long volatile *, long );
+
+} // namespace detail
+
+} // namespace boost
+
+# define BOOST_INTERLOCKED_INCREMENT ::boost::detail::InterlockedIncrement
+# define BOOST_INTERLOCKED_DECREMENT ::boost::detail::InterlockedDecrement
+# define BOOST_INTERLOCKED_COMPARE_EXCHANGE ::boost::detail::InterlockedCompareExchange
+# define BOOST_INTERLOCKED_EXCHANGE ::boost::detail::InterlockedExchange
+# define BOOST_INTERLOCKED_EXCHANGE_ADD ::boost::detail::InterlockedExchangeAdd
+
+# define BOOST_INTERLOCKED_COMPARE_EXCHANGE_POINTER(dest,exchange,compare) \
+    ((void*)BOOST_INTERLOCKED_COMPARE_EXCHANGE((long volatile*)(dest),(long)(exchange),(long)(compare)))
+# define BOOST_INTERLOCKED_EXCHANGE_POINTER(dest,exchange) \
+    ((void*)BOOST_INTERLOCKED_EXCHANGE((long volatile*)(dest),(long)(exchange)))
+
+#else
+
+# error "Interlocked intrinsics not available"
+
+#endif
+
+#endif // #ifndef BOOST_DETAIL_INTERLOCKED_HPP_INCLUDED

--- a/external/boost/smart_ptr/shared_ptr.hpp
+++ b/external/boost/smart_ptr/shared_ptr.hpp
@@ -208,6 +208,15 @@ public:
     }
 
 //  generated copy constructor, destructor are fine
+#if !defined( BOOST_NO_CXX11_RVALUE_REFERENCES )
+
+// ... except in C++0x, move disables the implicit copy
+
+    shared_ptr( shared_ptr const & r ) : px( r.px ), pn( r.pn )
+    {
+    }
+
+#endif
 
     template<class Y>
     explicit shared_ptr(weak_ptr<Y> const & r): pn(r.pn) // may throw


### PR DESCRIPTION
1. Fix compilation of certain sub-project. This requires to add in `boost/detail/interlocked.hpp`. Same version of it as of other boost headers is added into the project's `external/`. In additional, fixed `copy_on_write` program to be able to build on linux platform; such issue related to `boost::shared_ptr` missing a constructor to be compatible with c++11 and onwards.

2. Better organizational of source files as shown in visual studio by using folders as generated from cmake.

Before
![solution_as_before](https://user-images.githubusercontent.com/673757/95635917-fa537b00-0ab7-11eb-9abe-4e63b7151160.png)

After
![new_organized_vs_project](https://user-images.githubusercontent.com/673757/95635931-03444c80-0ab8-11eb-928a-bff4c7205c6a.png)
